### PR TITLE
Fix a crash due to pass NULL to std::wstring

### DIFF
--- a/LangBarButton.cpp
+++ b/LangBarButton.cpp
@@ -28,7 +28,6 @@ namespace Ime {
 
 LangBarButton::LangBarButton(TextService* service, const GUID& guid, UINT commandId, const wchar_t* text, DWORD style):
 	textService_(service),
-	tooltip_(NULL),
 	commandId_(commandId),
 	menu_(NULL),
 	icon_(NULL),


### PR DESCRIPTION
VC++ 2017 version internal uses wcslen to count the string length,
which requires not NULL