### PR TITLE
Add string header to TextService.h

### DIFF
--- a/TextService.cpp
+++ b/TextService.cpp
@@ -25,7 +25,6 @@
 #include "ImeModule.h"
 
 #include <assert.h>
-#include <string>
 #include <algorithm>
 
 using namespace std;

--- a/TextService.h
+++ b/TextService.h
@@ -29,6 +29,7 @@
 
 #include <vector>
 #include <list>
+#include <string>
 
 // for Windows 8 support
 #ifndef TF_TMF_IMMERSIVEMODE // this is defined in Win 8 SDK


### PR DESCRIPTION
MSVC 2019 is complaining the absence of this header.
```
error C2039:  'wstring': is not a member of 'std' 
```
https://ci.appveyor.com/project/Chocobo1/windows-chewing-tsf-build#L193